### PR TITLE
fix: Fix metrics endpoint response

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -18,7 +18,9 @@ const version = new prometheus.Gauge({
 function metricsEndpoint() {
     return (_req: express.Request, res: express.Response) => {
         res.writeHead(200, { 'Content-Type': 'text/plain' });
-        res.end(prometheus.register.metrics());
+        prometheus.register.metrics().then((body) => {
+            res.end(body);
+        });
     };
 }
 


### PR DESCRIPTION
Hey Jason,

First of all thanks for keeping this project around. I've been using it on my personal cluster for a while and it fully met my needs. Anything else that's remotely similar is probably much more difficult to set up.

Recently (probably once my cluster pulled the v0.2.0) I noticed that kube-auth-proxy was getting restarted all the time and I saw this in the logs:

```
TypeError [ERR_INVALID_ARG_TYPE]: The "chunk" argument must be of type string or an instance of Buffer or Uint8Array. Received an instance of Promise
    at new NodeError (node:internal/errors:371:5)
    at write_ (node:_http_outgoing:742:11)
    at ServerResponse.end (node:_http_outgoing:855:5)
    at /opt/app/dist/metrics.js:44:13
    at Layer.handle [as handle_request] (/opt/app/node_modules/express/lib/router/layer.js:95:5)
    at next (/opt/app/node_modules/express/lib/router/route.js:137:13)
    at Route.dispatch (/opt/app/node_modules/express/lib/router/route.js:112:3)
    at Layer.handle [as handle_request] (/opt/app/node_modules/express/lib/router/layer.js:95:5)
    at /opt/app/node_modules/express/lib/router/index.js:281:22
    at Function.process_params (/opt/app/node_modules/express/lib/router/index.js:335:12)
```

Looks like `.metrics()` now returns a promise and express' `res.end()` doesn't like a promise as an argument. 

I tried this fix on my cluster and it solves the problem. Prometheus can scrape the metrics endpoint again and I also tried curl-ing it.

Cheers